### PR TITLE
cREAL | Add deploy-new-asset-moola.ts and modify files for adding mcREAL

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -22,7 +22,7 @@ const DEFAULT_BLOCK_GAS_LIMIT = 12450000;
 const DEFAULT_GAS_MUL = 5;
 const HARDFORK = 'istanbul';
 const ETHERSCAN_KEY = process.env.ETHERSCAN_KEY || '';
-const MNEMONIC_PATH = "m/44'/60'/0'/0";
+const MNEMONIC_PATH = process.env.MNEMONIC_PATH || "m/44'/60'/0'/0";
 const MNEMONIC = process.env.MNEMONIC || '';
 const MAINNET_FORK = process.env.MAINNET_FORK === 'true';
 

--- a/helpers/constants.ts
+++ b/helpers/constants.ts
@@ -33,6 +33,7 @@ export const MOCK_CHAINLINK_AGGREGATORS_PRICES = {
   CELO: oneEther.toFixed(),
   CUSD: oneEther.multipliedBy('0.223359').toFixed(),
   CEUR: oneEther.multipliedBy('0.262277').toFixed(),
+  CREAL: oneEther.multipliedBy('0.040204').toFixed(),
   MOO: oneEther.multipliedBy('0.312155').toFixed(),
   UBE: oneEther.multipliedBy('0.161059').toFixed(),
   AAVE: oneEther.multipliedBy('0.003620948469').toFixed(),

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -210,6 +210,7 @@ export interface iAssetBase<T> {
   CUSD: T;
   CEUR: T;
   CELO: T;
+  CREAL: T;
   MOO: T;
   UBE: T;
   WETH: T;
@@ -320,7 +321,7 @@ export type iXDAIPoolAssets<T> = Pick<
 
 export type iMoolaPoolAssets<T> = Pick<
   iAssetsWithoutUSD<T>,
-  'CELO' | 'CUSD' | 'CEUR'
+  'CELO' | 'CUSD' | 'CEUR' | 'CREAL'
 >;
 
 export type iMultiPoolsAssets<T> = iAssetCommon<T> | iAavePoolAssets<T>;

--- a/markets/moola/commons.ts
+++ b/markets/moola/commons.ts
@@ -42,6 +42,9 @@ export const CommonsConfig: ICommonConfiguration = {
     CEUR: {
       borrowRate: oneRay.multipliedBy(0.039).toFixed(),
     },
+    CREAL: {
+      borrowRate: oneRay.multipliedBy(0.039).toFixed(),
+    },
     MOO: {
       borrowRate: oneRay.multipliedBy(0.03).toFixed(),
     },

--- a/markets/moola/index.ts
+++ b/markets/moola/index.ts
@@ -6,6 +6,7 @@ import {
   strategyCELO,
   strategyCUSD,
   strategyCEUR,
+  strategyCREAL,
 } from './reservesConfigs';
 
 // ----------------
@@ -20,17 +21,20 @@ export const MoolaConfig: IMoolaConfiguration = {
     CELO: strategyCELO,
     CUSD: strategyCUSD,
     CEUR: strategyCEUR,
+    CREAL: strategyCREAL,
   },
   ReserveAssets: {
     [eCeloNetwork.celo]: {
       CELO: '0x471EcE3750Da237f93B8E339c536989b8978a438',
       CUSD: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
       CEUR: '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
+      CREAL: '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
     },
     [eCeloNetwork.alfajores]: {
       CELO: '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
       CUSD: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
       CEUR: '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
+      CREAL: '0xE4D517785D091D3c54818832dB6094bcc2744545',
     },
   },
 };

--- a/markets/moola/rateStrategies.ts
+++ b/markets/moola/rateStrategies.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 import { oneRay } from '../../helpers/constants';
 import { IInterestRateStrategyParams } from '../../helpers/types';
 
-// CUSD CEUR
+// CUSD CEUR CREAL
 export const rateStrategyStableTwo: IInterestRateStrategyParams = {
   name: "rateStrategyStableTwo",
   optimalUtilizationRate: new BigNumber(0.8).multipliedBy(oneRay).toFixed(),

--- a/markets/moola/reservesConfigs.ts
+++ b/markets/moola/reservesConfigs.ts
@@ -41,7 +41,6 @@ export const strategyCREAL: IReserveParams = {
   reserveFactor: '1000',
 };
 
-
 export const strategyCELO: IReserveParams = {
   strategy: rateStrategyCELO,
   baseLTVAsCollateral: '8000',

--- a/markets/moola/reservesConfigs.ts
+++ b/markets/moola/reservesConfigs.ts
@@ -29,6 +29,19 @@ export const strategyCEUR: IReserveParams = {
   reserveFactor: '1000'
 };
 
+export const strategyCREAL: IReserveParams = {
+  strategy: rateStrategyStableTwo,
+  baseLTVAsCollateral: '7500',
+  liquidationThreshold: '8000',
+  liquidationBonus: '10500',
+  borrowingEnabled: true,
+  stableBorrowRateEnabled: true,
+  reserveDecimals: '18',
+  aTokenImpl: eContractid.AToken,
+  reserveFactor: '1000',
+};
+
+
 export const strategyCELO: IReserveParams = {
   strategy: rateStrategyCELO,
   baseLTVAsCollateral: '8000',

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "external:deploy-assets-kovan": "npm run compile && hardhat --network kovan external:deploy-new-asset --symbol ${SYMBOL} --verify",
     "external:deploy-assets-main": "npm run compile && hardhat --network main external:deploy-new-asset --symbol ${SYMBOL} --verify",
     "external:deploy-assets-moola-alfajores": "npm run compile && hardhat --network alfajores external:deploy-new-asset-moola --symbol ${SYMBOL} --verify",
+    "external:deploy-assets-moola-main": "npm run compile && hardhat --network main external:deploy-new-asset-moola --symbol ${SYMBOL} --verify",
     "prepublishOnly": "npm run compile",
     "moola:alfajores:full:migration": "npm run compile && npm run hardhat:alfajores -- moola:alfajores",
     "moola:celo:full:migration": "npm run compile && npm run hardhat:celo -- moola:celo"

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "kovan:initialize-tokens": "npm run compile && hardhat --network kovan full:initialize-tokens --pool Aave",
     "external:deploy-assets-kovan": "npm run compile && hardhat --network kovan external:deploy-new-asset --symbol ${SYMBOL} --verify",
     "external:deploy-assets-main": "npm run compile && hardhat --network main external:deploy-new-asset --symbol ${SYMBOL} --verify",
+    "external:deploy-assets-moola-alfajores": "npm run compile && hardhat --network alfajores external:deploy-new-asset-moola --symbol ${SYMBOL} --verify",
     "prepublishOnly": "npm run compile",
     "moola:alfajores:full:migration": "npm run compile && npm run hardhat:alfajores -- moola:alfajores",
     "moola:celo:full:migration": "npm run compile && npm run hardhat:celo -- moola:celo"

--- a/package.json
+++ b/package.json
@@ -81,8 +81,8 @@
     "kovan:initialize-tokens": "npm run compile && hardhat --network kovan full:initialize-tokens --pool Aave",
     "external:deploy-assets-kovan": "npm run compile && hardhat --network kovan external:deploy-new-asset --symbol ${SYMBOL} --verify",
     "external:deploy-assets-main": "npm run compile && hardhat --network main external:deploy-new-asset --symbol ${SYMBOL} --verify",
-    "external:deploy-assets-moola-alfajores": "npm run compile && hardhat --network alfajores external:deploy-new-asset-moola --symbol ${SYMBOL} --verify",
-    "external:deploy-assets-moola-main": "npm run compile && hardhat --network main external:deploy-new-asset-moola --symbol ${SYMBOL} --verify",
+    "external:deploy-assets-moola-alfajores": "npm run compile && hardhat --network alfajores external:deploy-new-asset-moola --symbol ${SYMBOL}",
+    "external:deploy-assets-moola-main": "npm run compile && hardhat --network main external:deploy-new-asset-moola --symbol ${SYMBOL}",
     "prepublishOnly": "npm run compile",
     "moola:alfajores:full:migration": "npm run compile && npm run hardhat:alfajores -- moola:alfajores",
     "moola:celo:full:migration": "npm run compile && npm run hardhat:celo -- moola:celo"

--- a/tasks/helpers/deploy-new-asset-moola.ts
+++ b/tasks/helpers/deploy-new-asset-moola.ts
@@ -25,8 +25,7 @@ const isSymbolValid = (symbol: string, network: eCeloNetwork) =>
 
 task('external:deploy-new-asset-moola', 'Deploy A token, Debt Tokens, Risk Parameters')
   .addParam('symbol', `Asset symbol, needs to have configuration ready`)
-  .addFlag('verify', 'Verify contracts at Etherscan')
-  .setAction(async ({ verify, symbol }, localBRE) => {
+  .setAction(async ({ symbol }, localBRE) => {
     const network = localBRE.network.name;
     if (!isSymbolValid(symbol, network as eCeloNetwork)) {
       throw new Error(
@@ -48,6 +47,7 @@ WRONG RESERVE ASSET SETUP:
     );
     const poolAddress = await addressProvider.getLendingPool();
     const treasuryAddress = await getTreasuryAddress(marketConfigs.MoolaConfig);
+
     const aToken = await deployCustomAToken(
       [
         poolAddress,
@@ -57,7 +57,7 @@ WRONG RESERVE ASSET SETUP:
         `Moola interest bearing ${symbol}`,
         `m${symbol}`,
       ],
-      verify
+      false
     );
     const stableDebt = await deployStableDebtToken(
       [
@@ -67,7 +67,7 @@ WRONG RESERVE ASSET SETUP:
         `Moola stable debt bearing ${symbol}`,
         `stableDebt${symbol}`,
       ],
-      verify
+      false
     );
     const variableDebt = await deployVariableDebtToken(
       [
@@ -77,19 +77,20 @@ WRONG RESERVE ASSET SETUP:
         `Moola variable debt bearing ${symbol}`,
         `variableDebt${symbol}`,
       ],
-      verify
+      false
     );
+    const { rateStrategy } = strategyParams;
     const rates = await deployDefaultReserveInterestRateStrategy(
       [
         addressProvider.address,
-        strategyParams.optimalUtilizationRate,
-        strategyParams.baseVariableBorrowRate,
-        strategyParams.variableRateSlope1,
-        strategyParams.variableRateSlope2,
-        strategyParams.stableRateSlope1,
-        strategyParams.stableRateSlope2,
+        rateStrategy.optimalUtilizationRate,
+        rateStrategy.baseVariableBorrowRate,
+        rateStrategy.variableRateSlope1,
+        rateStrategy.variableRateSlope2,
+        rateStrategy.stableRateSlope1,
+        rateStrategy.stableRateSlope2,
       ],
-      verify
+      false
     );
     console.log(`
     New interest bearing asset deployed on ${network}:

--- a/tasks/helpers/deploy-new-asset-moola.ts
+++ b/tasks/helpers/deploy-new-asset-moola.ts
@@ -79,7 +79,7 @@ WRONG RESERVE ASSET SETUP:
       ],
       false
     );
-    const { rateStrategy } = strategyParams;
+    const { strategy: rateStrategy } = strategyParams;
     const rates = await deployDefaultReserveInterestRateStrategy(
       [
         addressProvider.address,

--- a/tasks/helpers/deploy-new-asset-moola.ts
+++ b/tasks/helpers/deploy-new-asset-moola.ts
@@ -1,0 +1,101 @@
+import { task } from 'hardhat/config';
+import { eCeloNetwork } from '../../helpers/types';
+import { getTreasuryAddress } from '../../helpers/configuration';
+import * as marketConfigs from '../../markets/moola';
+import * as reserveConfigs from '../../markets/moola/reservesConfigs';
+import { chooseATokenDeployment } from '../../helpers/init-helpers';
+import { getLendingPoolAddressesProvider } from '../../helpers/contracts-getters';
+import {
+  deployDefaultReserveInterestRateStrategy,
+  deployStableDebtToken,
+  deployVariableDebtToken,
+} from '../../helpers/contracts-deployments';
+import { setDRE } from '../../helpers/misc-utils';
+import { ZERO_ADDRESS } from '../../helpers/constants';
+
+const LENDING_POOL_ADDRESS_PROVIDER = {
+  main: '0xD1088091A174d33412a968Fa34Cb67131188B332',
+  alfajores: '0xb3072f5F0d5e8B9036aEC29F37baB70E86EA0018',
+};
+
+const isSymbolValid = (symbol: string, network: eCeloNetwork) =>
+  Object.keys(reserveConfigs).includes('strategy' + symbol) &&
+  marketConfigs.MoolaConfig.ReserveAssets[network][symbol] &&
+  marketConfigs.MoolaConfig.ReservesConfig[symbol] === reserveConfigs['strategy' + symbol];
+
+task('external:deploy-new-asset-moola', 'Deploy A token, Debt Tokens, Risk Parameters')
+  .addParam('symbol', `Asset symbol, needs to have configuration ready`)
+  .addFlag('verify', 'Verify contracts at Etherscan')
+  .setAction(async ({ verify, symbol }, localBRE) => {
+    const network = localBRE.network.name;
+    if (!isSymbolValid(symbol, network as eCeloNetwork)) {
+      throw new Error(
+        `
+WRONG RESERVE ASSET SETUP:
+        The symbol ${symbol} has no reserve Config and/or reserve Asset setup.
+        update /markets/moola/index.ts and add the asset address for ${network} network
+        update /markets/moola/reservesConfigs.ts and add parameters for ${symbol}
+        `
+      );
+    }
+    setDRE(localBRE);
+    const strategyParams = reserveConfigs['strategy' + symbol];
+    const reserveAssetAddress =
+      marketConfigs.MoolaConfig.ReserveAssets[localBRE.network.name][symbol];
+    const deployCustomAToken = chooseATokenDeployment(strategyParams.aTokenImpl);
+    const addressProvider = await getLendingPoolAddressesProvider(
+      LENDING_POOL_ADDRESS_PROVIDER[network]
+    );
+    const poolAddress = await addressProvider.getLendingPool();
+    const treasuryAddress = await getTreasuryAddress(marketConfigs.MoolaConfig);
+    const aToken = await deployCustomAToken(
+      [
+        poolAddress,
+        reserveAssetAddress,
+        treasuryAddress,
+        ZERO_ADDRESS, // Incentives Controller
+        `Moola interest bearing ${symbol}`,
+        `m${symbol}`,
+      ],
+      verify
+    );
+    const stableDebt = await deployStableDebtToken(
+      [
+        poolAddress,
+        reserveAssetAddress,
+        ZERO_ADDRESS, // Incentives Controller
+        `Moola stable debt bearing ${symbol}`,
+        `stableDebt${symbol}`,
+      ],
+      verify
+    );
+    const variableDebt = await deployVariableDebtToken(
+      [
+        poolAddress,
+        reserveAssetAddress,
+        ZERO_ADDRESS, // Incentives Controller
+        `Moola variable debt bearing ${symbol}`,
+        `variableDebt${symbol}`,
+      ],
+      verify
+    );
+    const rates = await deployDefaultReserveInterestRateStrategy(
+      [
+        addressProvider.address,
+        strategyParams.optimalUtilizationRate,
+        strategyParams.baseVariableBorrowRate,
+        strategyParams.variableRateSlope1,
+        strategyParams.variableRateSlope2,
+        strategyParams.stableRateSlope1,
+        strategyParams.stableRateSlope2,
+      ],
+      verify
+    );
+    console.log(`
+    New interest bearing asset deployed on ${network}:
+    Interest bearing m${symbol} address: ${aToken.address}
+    Variable Debt variableDebt${symbol} address: ${variableDebt.address}
+    Stable Debt stableDebt${symbol} address: ${stableDebt.address}
+    Strategy Implementation for ${symbol} address: ${rates.address}
+    `);
+  });


### PR DESCRIPTION
- Create a new file `tasks/helpers/deploy-new-asset-moola.ts` which is copied & modified from `tasks/helpers/deploy-new-asset.ts` that should enable the command to deploy a new asset and related debt and strategy contracts
- Modify `helpers/constants.ts` to add CREAL to `MOCK_CHAINLINK_AGGREGATORS_PRICES`
- Modify files in `markets/moola` to add cREAL address and `strategyCREAL`
- Modify `package.json` to add deploy commands to mainnet and alfajores