### PR TITLE
Credit delegation | Update RepayDelegationHelper to also repay debt in the other mode

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -285,7 +285,7 @@ async function execute(network, action, ...params) {
       ubeswap = new kit.web3.eth.Contract(Uniswap, '0xe3d8bd6aed4f159bc8000a9cd47cffdb95f96121');
       repayDelegationHelper = new kit.web3.eth.Contract(
         RepayDelegationHelper,
-        '0x70ff7BC486BFAE2F1ED11C966Fe49d2681dE991e'
+        '0xfc3F43C83ec585480e542aD552E187eCA4737940'
       );
       // leverageBorrowAdapter = new kit.web3.eth.Contract(LeverageBorrowAdapter, '0x7e7D2f9Ef635EC83DF06838eA4dc8053055a9F29');
       break;
@@ -324,7 +324,7 @@ async function execute(network, action, ...params) {
       );
       repayDelegationHelper = new kit.web3.eth.Contract(
         RepayDelegationHelper,
-        '0x4768028b351a65d266074881cCf6D16E7796f8F9'
+        '0x480bB7669e15F96a85cf0CD4E766C368702b79Aa'
       );
       break;
     default:

--- a/cli.js
+++ b/cli.js
@@ -4,7 +4,7 @@ const LendingPool = require('./abi/LendingPool.json');
 const PriceOracle = require('./abi/PriceOracle.json');
 const UniswapRepayAdapter = require('./abi/UniswapRepayAdapter.json');
 const AutoRepay = require('./abi/AutoRepay.json');
-const LeverageBorrowAdapter = require('./abi/LeverageBorrowAdapter.json')
+const LeverageBorrowAdapter = require('./abi/LeverageBorrowAdapter.json');
 const Uniswap = require('./abi/Uniswap.json');
 const DataProvider = require('./abi/MoolaProtocolDataProvider.json');
 const MToken = require('./abi/MToken.json');
@@ -138,11 +138,13 @@ function buildLeverageBorrowParams(
   useATokenAsTo,
   useEthPath,
   toAsset,
-  minAmountOut,
+  minAmountOut
 ) {
   return ethers.utils.defaultAbiCoder.encode(
-    ['tuple(bool useATokenAsFrom, bool useATokenAsTo, bool useEthPath, address toAsset, uint256 minAmountOut)[]'],
-    [[{useATokenAsFrom, useATokenAsTo, useEthPath, toAsset, minAmountOut}]]
+    [
+      'tuple(bool useATokenAsFrom, bool useATokenAsTo, bool useEthPath, address toAsset, uint256 minAmountOut)[]',
+    ],
+    [[{ useATokenAsFrom, useATokenAsTo, useEthPath, toAsset, minAmountOut }]]
   );
 }
 
@@ -214,7 +216,9 @@ function printActions() {
     'liquidationCall collateral-asset debt-asset risk-user debt-to-cover receive-AToken(true|false) address [privateKey]'
   );
   console.info('repayDelegation delegator asset amount stable|variable address [privateKey]');
-  console.info('leverage-borrow address collateral-asset debt-asset stable|variable debt-amount [privateKey]');
+  console.info(
+    'leverage-borrow address collateral-asset debt-asset stable|variable debt-amount [privateKey]'
+  );
 }
 
 const retry = async (fun, tries = 5) => {
@@ -281,7 +285,7 @@ async function execute(network, action, ...params) {
       ubeswap = new kit.web3.eth.Contract(Uniswap, '0xe3d8bd6aed4f159bc8000a9cd47cffdb95f96121');
       repayDelegationHelper = new kit.web3.eth.Contract(
         RepayDelegationHelper,
-        '0x954234d95900AD58fAB116EcF6a454b4C3255913'
+        '0x70ff7BC486BFAE2F1ED11C966Fe49d2681dE991e'
       );
       // leverageBorrowAdapter = new kit.web3.eth.Contract(LeverageBorrowAdapter, '0x7e7D2f9Ef635EC83DF06838eA4dc8053055a9F29');
       break;
@@ -314,7 +318,10 @@ async function execute(network, action, ...params) {
         '0xCC321F48CF7bFeFe100D1Ce13585dcfF7627f754'
       );
       ubeswap = new kit.web3.eth.Contract(Uniswap, '0xe3d8bd6aed4f159bc8000a9cd47cffdb95f96121');
-      leverageBorrowAdapter = new kit.web3.eth.Contract(LeverageBorrowAdapter, '0x7e7D2f9Ef635EC83DF06838eA4dc8053055a9F29');
+      leverageBorrowAdapter = new kit.web3.eth.Contract(
+        LeverageBorrowAdapter,
+        '0x7e7D2f9Ef635EC83DF06838eA4dc8053055a9F29'
+      );
       break;
     default:
       try {
@@ -352,7 +359,10 @@ async function execute(network, action, ...params) {
         '0xCC321F48CF7bFeFe100D1Ce13585dcfF7627f754'
       );
       ubeswap = new kit.web3.eth.Contract(Uniswap, '0xe3d8bd6aed4f159bc8000a9cd47cffdb95f96121');
-      leverageBorrowAdapter = new kit.web3.eth.Contract(LeverageBorrowAdapter, '0x7e7D2f9Ef635EC83DF06838eA4dc8053055a9F29');
+      leverageBorrowAdapter = new kit.web3.eth.Contract(
+        LeverageBorrowAdapter,
+        '0x7e7D2f9Ef635EC83DF06838eA4dc8053055a9F29'
+      );
   }
   const web3 = kit.web3;
   const eth = web3.eth;
@@ -398,12 +408,18 @@ async function execute(network, action, ...params) {
   const getUseMTokenFromTo = async (tokenFrom, tokenTo, amount) => {
     const mFrom = await getMTokenAddress(tokenFrom);
     const mTo = await getMTokenAddress(tokenTo);
-    const result = await Promise.reduce([[tokenFrom, tokenTo], [tokenFrom, mTo], [mFrom, mTo], [mFrom, tokenTo]],
+    const result = await Promise.reduce(
+      [
+        [tokenFrom, tokenTo],
+        [tokenFrom, mTo],
+        [mFrom, mTo],
+        [mFrom, tokenTo],
+      ],
       async (res, [tFrom, tTo]) => {
         let amountOut = BN(0);
         try {
           amountOut = BN((await ubeswap.methods.getAmountsOut(amount, [tFrom, tTo]).call())[1]);
-        } catch(err) {
+        } catch (err) {
           return res;
         }
         if (amountOut.gt(res.amountOut)) {
@@ -412,7 +428,9 @@ async function execute(network, action, ...params) {
           res.amountOut = amountOut;
         }
         return res;
-      }, {tokenFrom: '', tokenTo: '', amountOut: BN(0)});
+      },
+      { tokenFrom: '', tokenTo: '', amountOut: BN(0) }
+    );
     result.useMTokenAsFrom = mFrom === result.tokenFrom;
     result.useMTokenAsTo = mTo === result.tokenTo;
     return result;
@@ -1682,9 +1700,7 @@ async function execute(network, action, ...params) {
 
   if (action === 'leverage-borrow') {
     if (network == 'test') {
-      throw new Error(
-        'leverage-borrow only works on the mainnet due to low liquidity in pools'
-      );
+      throw new Error('leverage-borrow only works on the mainnet due to low liquidity in pools');
     }
 
     if (privateKeyRequired) {
@@ -1711,7 +1727,11 @@ async function execute(network, action, ...params) {
     const rateMode = params[3] === 'stable' ? 1 : 2;
     const debtAmount = BN(web3.utils.toWei(params[4]));
 
-    const {useMTokenAsFrom, useMTokenAsTo, amountOut} = await getUseMTokenFromTo(debtAsset, collateralAsset, debtAmount);
+    const { useMTokenAsFrom, useMTokenAsTo, amountOut } = await getUseMTokenFromTo(
+      debtAsset,
+      collateralAsset,
+      debtAmount
+    );
 
     const callParams = buildLeverageBorrowParams(
       useMTokenAsFrom,

--- a/cli.js
+++ b/cli.js
@@ -285,7 +285,7 @@ async function execute(network, action, ...params) {
       ubeswap = new kit.web3.eth.Contract(Uniswap, '0xe3d8bd6aed4f159bc8000a9cd47cffdb95f96121');
       repayDelegationHelper = new kit.web3.eth.Contract(
         RepayDelegationHelper,
-        '0xfc3F43C83ec585480e542aD552E187eCA4737940'
+        '0xeEe3D107c387B04A8e07B7732f0ED0f6ED990882'
       );
       // leverageBorrowAdapter = new kit.web3.eth.Contract(LeverageBorrowAdapter, '0x7e7D2f9Ef635EC83DF06838eA4dc8053055a9F29');
       break;

--- a/contracts/protocol/lendingpool/RepayDelegationHelper.sol
+++ b/contracts/protocol/lendingpool/RepayDelegationHelper.sol
@@ -27,7 +27,7 @@ contract RepayDelegationHelper {
    * @param _delegator The wallet address to repay debt of
    * @param _asset The asset address to repay
    * @param _amount The amount to repay
-   * @param _rateMode The rateMode to use for repayment
+   * @param _rateMode The rateMode to use for repayment: 1 for Stable, 2 for Variable
    */
   function repayDelegation(
     address _delegator,
@@ -50,7 +50,18 @@ contract RepayDelegationHelper {
     );
 
     uint256 remaining = _amount - paybackAmount;
+
     if (remaining > 0) {
+      uint256 otherRateMode = _rateMode == 1 ? 2 : 1;
+      uint256 otherRateModePaybackAmount = ILendingPool(lendingPoolAddress).repay(
+        _asset,
+        remaining,
+        otherRateMode,
+        _delegator
+      );
+
+      remaining -= otherRateModePaybackAmount;
+
       ILendingPool(lendingPoolAddress).deposit(_asset, remaining, _delegator, 0);
     }
 

--- a/contracts/protocol/lendingpool/RepayDelegationHelper.sol
+++ b/contracts/protocol/lendingpool/RepayDelegationHelper.sol
@@ -43,6 +43,7 @@ contract RepayDelegationHelper {
     IERC20(_asset).safeApprove(lendingPoolAddress, _amount);
 
     uint256 remaining = _amount;
+
     try ILendingPool(lendingPoolAddress).repay(_asset, _amount, _rateMode, _delegator) returns (
       uint256 _paybackAmount
     ) {

--- a/contracts/protocol/lendingpool/RepayDelegationHelper.sol
+++ b/contracts/protocol/lendingpool/RepayDelegationHelper.sol
@@ -1,7 +1,6 @@
 pragma solidity 0.6.12;
 
 import {ILendingPoolAddressesProvider} from '../../interfaces/ILendingPoolAddressesProvider.sol';
-import {AaveProtocolDataProvider} from '../../misc/AaveProtocolDataProvider.sol';
 import {ILendingPool} from '../../interfaces/ILendingPool.sol';
 import {IERC20} from '../../dependencies/openzeppelin/contracts/IERC20.sol';
 import {SafeERC20} from '../../dependencies/openzeppelin/contracts/SafeERC20.sol';

--- a/contracts/protocol/lendingpool/RepayDelegationHelper.sol
+++ b/contracts/protocol/lendingpool/RepayDelegationHelper.sol
@@ -62,7 +62,9 @@ contract RepayDelegationHelper {
 
       remaining -= otherRateModePaybackAmount;
 
-      ILendingPool(lendingPoolAddress).deposit(_asset, remaining, _delegator, 0);
+      if (remaining > 0) {
+        ILendingPool(lendingPoolAddress).deposit(_asset, remaining, _delegator, 0);
+      }
     }
 
     emit DelegatedRepayment(_delegator, msg.sender, _asset, _amount, _rateMode);

--- a/contracts/protocol/lendingpool/RepayDelegationHelper.sol
+++ b/contracts/protocol/lendingpool/RepayDelegationHelper.sol
@@ -5,7 +5,6 @@ import {AaveProtocolDataProvider} from '../../misc/AaveProtocolDataProvider.sol'
 import {ILendingPool} from '../../interfaces/ILendingPool.sol';
 import {IERC20} from '../../dependencies/openzeppelin/contracts/IERC20.sol';
 import {SafeERC20} from '../../dependencies/openzeppelin/contracts/SafeERC20.sol';
-import {DataTypes} from '../libraries/types/DataTypes.sol';
 
 contract RepayDelegationHelper {
   using SafeERC20 for IERC20;
@@ -20,7 +19,7 @@ contract RepayDelegationHelper {
 
   ILendingPoolAddressesProvider public immutable ADDRESSES_PROVIDER;
 
-  constructor(ILendingPoolAddressesProvider addressesProvider, address dataProviderAddress) public {
+  constructor(ILendingPoolAddressesProvider addressesProvider) public {
     ADDRESSES_PROVIDER = addressesProvider;
   }
 
@@ -56,12 +55,10 @@ contract RepayDelegationHelper {
     if (remaining > 0) {
       uint256 otherRateMode = _rateMode == 1 ? 2 : 1;
 
-      uint256 otherRateModePaybackAmount = 0;
       try
         ILendingPool(lendingPoolAddress).repay(_asset, remaining, otherRateMode, _delegator)
       returns (uint256 _otherRateModePaybackAmount) {
-        otherRateModePaybackAmount = _otherRateModePaybackAmount;
-        remaining -= otherRateModePaybackAmount;
+        remaining -= _otherRateModePaybackAmount;
       } catch {}
 
       if (remaining > 0) {

--- a/contracts/protocol/lendingpool/RepayDelegationHelper.sol
+++ b/contracts/protocol/lendingpool/RepayDelegationHelper.sol
@@ -42,14 +42,12 @@ contract RepayDelegationHelper {
     IERC20(_asset).safeApprove(lendingPoolAddress, 0);
     IERC20(_asset).safeApprove(lendingPoolAddress, _amount);
 
-    uint256 paybackAmount = 0;
+    uint256 remaining = _amount;
     try ILendingPool(lendingPoolAddress).repay(_asset, _amount, _rateMode, _delegator) returns (
       uint256 _paybackAmount
     ) {
-      paybackAmount = _paybackAmount;
+      remaining -= _paybackAmount;
     } catch {}
-
-    uint256 remaining = _amount - paybackAmount;
 
     if (remaining > 0) {
       uint256 otherRateMode = _rateMode == 1 ? 2 : 1;


### PR DESCRIPTION
## Description:
- Update RepayDelegationHelper contract:
    - After trying to repay the debt in the specified rateMode, also tries to repay debt in the other rateMode of the remaining amount. Then transfer the remaining to delegator if there is still something left after repaying debt in both rateModes. 
    - If nothing is left after repaying debt in the specified rateMode, skip the whole step
    - Use try catch to prevent repayment failing due due to `validationLogic.validateRepay`


- Update cli.js with new contract addresses
    - Alfajores:
[0xeEe3D107c387B04A8e07B7732f0ED0f6ED990882](https://alfajores-blockscout.celo-testnet.org/address/0xeEe3D107c387B04A8e07B7732f0ED0f6ED990882/contracts)
    - Celo:
[0x480bB7669e15F96a85cf0CD4E766C368702b79Aa](https://explorer.celo.org/address/0x480bB7669e15F96a85cf0CD4E766C368702b79Aa/contracts)
