### PR TITLE
Update swap path cREAL / MOO, MOO / CELO

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1756,8 +1756,8 @@ async function execute(network, action, ...params) {
     };
     paths[`${MOO.options.address}_${CELO.options.address}`.toLowerCase()] = {
       path: [...celo_moo].reverse(),
-      useATokenAsFrom: true,
-      useATokenAsTo: false,
+      useATokenAsFrom: false,
+      useATokenAsTo: true,
     };
     paths[`${cEUR.options.address}_${cUSD.options.address}`.toLowerCase()] = {
       path: [...cusd_ceur].reverse(),


### PR DESCRIPTION
Found a mistake in the swap path for cREAL and MOO that caused repay MOO debt using cREAL collateral to fail. The error code was 1: Errors.VL_INVALID_AMOUNT. 

After updating the swap path, repay is working.
One successful transaction: 
https://explorer.celo.org/mainnet/tx/0x071d1e4e68711c9ac68b8071f2cb215fa57a65cd53e95b764a73e97952abc9ca/token-transfers

Eventually, this should be updated to use the path generation logic from Artem's auto repay bot PR, but before that PR is merged, I think we probably can continue using this for now 🤔

Related JIRA ticket:
https://moolamarket.atlassian.net/browse/AMM-1664